### PR TITLE
Fix PWA for Brave

### DIFF
--- a/jail/bin/brave.in
+++ b/jail/bin/brave.in
@@ -5,7 +5,7 @@
 #
 
 export BRAVE_PATH="/opt/brave.com/brave/brave"
-export BRAVE_WRAPPER="`readlink -f "$0"`"
+export CHROME_WRAPPER="`readlink -f "$0"`"
 export LD_LIBRARY_PATH=/usr/local/steam-utils/lib64/fakeudev
 export LD_PRELOAD=/usr/local/steam-utils/lib64/webfix/webfix.so
 export LIBGL_DRI3_DISABLE=1


### PR DESCRIPTION
Looks like Brave is actually identified as Chrome underneath so "BRAVE_WRAPPER" doesn't do anything. This corrects the wrapper variable name to actually fix PWA.