### PR TITLE
Updated Opera's binary path to .../opera-stable/opera

### DIFF
--- a/linux-browser-installer
+++ b/linux-browser-installer
@@ -5,7 +5,7 @@ browser_list=$(cat << END
 chrome:/opt/google/chrome/chrome
 vivaldi:/opt/vivaldi/vivaldi
 brave:/opt/brave.com/brave/brave
-opera:/usr/lib/x86_64-linux-gnu/opera/opera
+opera:/usr/lib/x86_64-linux-gnu/opera-stable/opera
 edge:/opt/microsoft/msedge/microsoft-edge
 END
 )


### PR DESCRIPTION
Now the Ubuntu default installation of `opera-stable` package wants to put the binary at `/usr/lib/x86_64-linux-gnu/opera-stable/opera`. Without the `-stable` the installed opera won't run.